### PR TITLE
Cut Type selector when importing DXF

### DIFF
--- a/easel/app.js
+++ b/easel/app.js
@@ -1,7 +1,8 @@
 var properties = function (projectSettings) {
   return [
     { id: "DXF File", type: "file-input", mimeTypes: [".dxf"] },
-    { type: 'list', id: "Lines Mode", value: "Joined", options: ["Separate", "Joined"] }
+    { type: 'list', id: "Lines Mode", value: "Joined", options: ["Separate", "Joined"] },
+    { type: "list", id: "Cut Path", value: "On Path", options: ["On Path", "Outside", "Inside"] }
   ];
 };
 
@@ -109,6 +110,19 @@ var executor = function (args, success, failure) {
         var fillColor = "#666";
         var strokeColor = "none";
         var volumes = [];
+        var cutType = null;
+
+        switch(params["Cut Path"]) {
+          case "Outside":
+            cutType = "outside";
+            break;
+          case "Inside":
+            cutType = "inside";
+            break;
+          case "On Path":
+            cutType = "on-path";
+            break;
+        }
 
         svg = svg
           .replace(/INSUNITS/g, args.preferredUnit)
@@ -136,10 +150,11 @@ var executor = function (args, success, failure) {
         newDataVolume.shape.tabPreference = true;
         newDataVolume.shape.points = sortPoints(newDataVolume.shape.points);
 
+
         var testVolume = EASEL.pathUtils.fromPointArrays(newDataVolume.shape.points);
         testVolume.cut = {
           type: "outline",
-          outlineStyle: "on-path",
+          outlineStyle: cutType,
           tabPreference: false,
           depth: args.material.dimensions.z
         };
@@ -149,7 +164,7 @@ var executor = function (args, success, failure) {
             testVolume = EASEL.pathUtils.fromPointArrays([newDataVolume.shape.points[i]]);
             testVolume.cut = {
               type: "outline",
-              outlineStyle: "on-path",
+              outlineStyle: cutType,
               tabPreference: false,
               depth: args.material.dimensions.z
             };


### PR DESCRIPTION
Allows the user to set the cut type when importing DXF apps.
Post-release of the 2.0 dxf app I have had 2 people contact me on the forum asking for this feature, as some CAD drawings do require different cuts. After recommending changing the cut type per shape users reported seeing the following error:
```
Cannot offset open paths
If you've imported an SVG, check for open paths and join them before importing.
```

This suggests there's still a bug in the way lines are connected in the app. In the meantime I have opted to add the selector to allow users to import with the cut type they would want in Easel.

![Screenshot_20200204_084135](https://user-images.githubusercontent.com/664346/73755117-28afd800-472b-11ea-8e4e-3681506e863a.png)
