### PR TITLE
Close the paths when first and last point are very close together

### DIFF
--- a/easel/app.js
+++ b/easel/app.js
@@ -72,6 +72,14 @@ function sortPoints(points) {
       }
     }
   }
+
+  if (points.length) {
+    // close the path if first and last point are close enough to make the path open due to dxf -> svg floating point inaccuracies
+    if (Math.abs(points[0].x - points[points.length - 1].x) < diff && Math.abs(points[0].y - points[points.length - 1].y) < diff ) {
+      points[points.length - 1] = points[0];
+    }
+  }
+
   return points;
 }
 


### PR DESCRIPTION
Fixes https://github.com/inventables/easel/issues/4945

When importing a DXF we use a node utility that coverts the file to SVG
https://github.com/inventables/dxfimport/blob/dd197d6daf7a636f18d0f20c5081a73e57f1fb0d/lambda/app.js#L15
Due to some floating point inaccuracies sometimes the paths that were meant to be closed are left open.

In the case of the file in https://github.com/inventables/easel/issues/4945 looking at one of the shapes shows the following points as being first and last
```
> points = EASEL.volumeStore.getVolumes()[0].shape.points[0]
Array(1656) [ {…}, {…}, {…}, {…}, {…}, {…}, {…}, {…}, {…}, {…}, … ]

> points[0].y - points[points.length - 1].y
3.999929276687908e-10
```

Because our logic of checking if the shape is open of closed relies on exact values used this check fails 
https://github.com/inventables/easel/blob/c5cbd7f7996fc0a2dcda4be941b1d29135e57a30/app/assets/javascripts/easel/utils/path.coffee#L22

Since the path is open it's up to debate which side is the _outside_ side and hence the error in https://github.com/inventables/easel/issues/4945

I have tested the fix by cloning the dxf import app locally and importing the test file that was having issues, and noticed that post fix the shape was represented correctly on both 2d and 3d side, and I was able to change inside/outside cut type without errors/

As a follow up we might look into patching our SVG import procedure to behave the same way and join paths that might appear open..