### PR TITLE
Auto metric/imperial conversion

### DIFF
--- a/easel/app.js
+++ b/easel/app.js
@@ -139,13 +139,14 @@ var executor = function (args, success, failure) {
             break;
         }
 
+        var transformRegex = /transform=\"scale\((\d*(\.(\d)+)?)\)\"/;
+        var scaleMatch = svg.match(transformRegex);
+        var scale = scaleMatch.length > 0 ? scaleMatch[1] : 1;
+
         svg = svg
-          .replace(/INSUNITS/g, args.preferredUnit)
+          .replace(transformRegex, '')
           .replace('fill="#000000"', 'fill="' + fillColor + '"')
           .replace('stroke="none"', 'stroke="' + strokeColor + '" stroke-width="5"');
-
-        var scaleMatch = svg.match(/scale=\"(\d*(\.(\d)+)?)\"/);
-        var scale = scaleMatch && scaleMatch.length > 0 ? scaleMatch[1] : 1;
 
         svg = filterSVG(svg);
 

--- a/easel/app.js
+++ b/easel/app.js
@@ -144,7 +144,8 @@ var executor = function (args, success, failure) {
           .replace('fill="#000000"', 'fill="' + fillColor + '"')
           .replace('stroke="none"', 'stroke="' + strokeColor + '" stroke-width="5"');
 
-        var divider = svg.includes("mm\" height=") ? 25.4 : 1;
+        var scaleMatch = svg.match(/scale=\"(\d*(\.(\d)+)?)\"/);
+        var scale = scaleMatch && scaleMatch.length > 0 ? scaleMatch[1] : 1;
 
         svg = filterSVG(svg);
 
@@ -156,9 +157,9 @@ var executor = function (args, success, failure) {
           depth: args.material.dimensions.z
         };
 
-        // The divider fixes METRIC - IMPERIAL issues
-        newDataVolume.shape.width = newDataVolume.shape.width / divider;
-        newDataVolume.shape.height = newDataVolume.shape.height / divider;
+        // The scale fixes unit issues with SVG being imported in px
+        newDataVolume.shape.width = newDataVolume.shape.width * scale;
+        newDataVolume.shape.height = newDataVolume.shape.height * scale;
         newDataVolume.shape.center.x = newDataVolume.shape.width / 2;
         newDataVolume.shape.center.y = newDataVolume.shape.height / 2;
         newDataVolume.shape.flipping.vertical = true;
@@ -189,10 +190,10 @@ var executor = function (args, success, failure) {
           var y = EASEL.volumeHelper.boundingBoxBottom(volumes);
 
           for (i = 0; i < volumes.length; i++) {
-            volumes[i].shape.center.x = (volumes[i].shape.center.x - x) / divider;
-            volumes[i].shape.center.y = (volumes[i].shape.center.y - y) / divider;
-            volumes[i].shape.width = volumes[i].shape.width / divider;
-            volumes[i].shape.height = volumes[i].shape.height / divider;
+            volumes[i].shape.center.x = (volumes[i].shape.center.x - x) * scale;
+            volumes[i].shape.center.y = (volumes[i].shape.center.y - y) * scale;
+            volumes[i].shape.width = volumes[i].shape.width * scale;
+            volumes[i].shape.height = volumes[i].shape.height * scale;
             volumes[i].shape.flipping.vertical = true;
             volumes[i].shape.tabPreference = true;
           }

--- a/lambda/app.js
+++ b/lambda/app.js
@@ -13,7 +13,7 @@ exports.handler = (event, context) => {
 
     const outputSVG = dxf
       .toSVG(dxf.parseString(dxfContents))
-      .replace(unitToken, determineUnits(dxfContents));
+      .replace('<svg', `<svg scale="${determineUnits(dxfContents)}"`);
 
     context.done(
       null,
@@ -36,13 +36,12 @@ function determineUnits(dxfContents) {
 
     switch (parseInt(units)) {
       case 1:
-        return "in";
+        return 1;
       case 4:
-        return "mm";
+        return 1/25.4;
       case 5:
-        return "cm";
+        return 1/2.54;
     }
   }
-
-  return unitToken;
+  return 1;
 }

--- a/lambda/app.js
+++ b/lambda/app.js
@@ -13,7 +13,7 @@ exports.handler = (event, context) => {
 
     const outputSVG = dxf
       .toSVG(dxf.parseString(dxfContents))
-      .replace('<svg', `<svg scale="${determineUnits(dxfContents)}"`);
+      .replace('<svg', `<svg transform="scale(${determineUnits(dxfContents)})"`);
 
     context.done(
       null,


### PR DESCRIPTION
This is another step trying to make the dxf app a bit more user friendly by sending the `transform="scale()"` param back. Unfortunately Easel has trouble importing such SVG so the param is stripped away, but used in processing the data back.

Eventually we can keep the lambda function same but update Easel to respect the scale parameter back.
I have tested the new app using _TestSanbox_ account, deploying the new app and running all the test files through it. I also ran the file below - it should import at roughly 640.2 x 392.7 mm.
Pre-changes it imports at 640.2 inches, post changes it imports at correct size.
[mft_template.zip](https://github.com/inventables/dxfimport/files/5113453/mft_template.zip)
File preview at AutoCAD Viewer Online:
![Screenshot_20200822_223129](https://user-images.githubusercontent.com/664346/90970219-9b19b700-e4c7-11ea-83ad-a2161a0ac33b.png)
Import before changes (current live version of the app)
![Screenshot_20200822_223322](https://user-images.githubusercontent.com/664346/90970223-a53bb580-e4c7-11ea-87b9-2c71c4e1e73c.png)
Import with changes from this PR
![Screenshot_20200822_223345](https://user-images.githubusercontent.com/664346/90970225-aec51d80-e4c7-11ea-8985-8714373d185b.png)



I used [AutoCAD documentation](https://knowledge.autodesk.com/support/autocad/learn-explore/caas/CloudHelp/cloudhelp/2016/ENU/AutoCAD-Core/files/GUID-A58A87BB-482B-4042-A00A-EEF55A2B4FD8-htm.html) as reference. If needed we can add more units being supported by Easel.
