### PR TITLE
fix failure passing object instead of string

### DIFF
--- a/easel/app.js
+++ b/easel/app.js
@@ -215,7 +215,7 @@ var executor = function (args, success, failure) {
     })
     .catch(function(err) {
       // There was some general Lambda errors when calling the API
-      failure(err)
+      failure(err.message)
     });
 };
 


### PR DESCRIPTION
### What does this PR do?
* Updates the callback param to be a string instead of an object

### Context
The app handling code expects a string to display. When we got an object, the UI would hang with the loading state and not display any error.

### Tested
Tested with the dxf import test app and verified the error message appeared for large dxf files.